### PR TITLE
Fix build error due to task API change

### DIFF
--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -47,7 +47,7 @@ bool waitForTaskStateChange(
   // Wait for task to transition to finished state.
   if (task->state() != state) {
     auto& executor = folly::QueuedImmediateExecutor::instance();
-    auto future = task->taskCompletionFuture(maxWaitMicros).via(&executor);
+    auto future = task->taskCompletionFuture().within(std::chrono::microseconds(maxWaitMicros)).via(&executor);
     future.wait();
   }
 


### PR DESCRIPTION
The build error addressed:

```
/root/oss/velox/velox/exec/tests/utils/Cursor.cpp: In function ‘bool facebook::velox::exec::test::waitForTaskStateChange(facebook::velox::exec::Task*, facebook::velox::exec::TaskState, uint64_t)’:
/root/oss/velox/velox/exec/tests/utils/Cursor.cpp:50:45: error: no matching function for call to ‘facebook::velox::exec::Task::taskCompletionFuture(uint64_t&)’
   50 |     auto future = task->taskCompletionFuture(maxWaitMicros).via(&executor);
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
In file included from /root/oss/velox/./velox/exec/tests/utils/Cursor.h:19,
                 from /root/oss/velox/velox/exec/tests/utils/Cursor.cpp:16:
/root/oss/velox/./velox/exec/Task.h:270:18: note: candidate: ‘facebook::velox::ContinueFuture facebook::velox::exec::Task::taskCompletionFuture()’
  270 |   ContinueFuture taskCompletionFuture();
      |                  ^~~~~~~~~~~~~~~~~~~~
/root/oss/velox/./velox/exec/Task.h:270:18: note:   candidate expects 0 arguments, 1 provided
[180/540] Building CXX object velox/expression/CMakeFiles/velox_expression.dir/CastExpr.cpp.o
ninja: build stopped: subcommand failed.
```